### PR TITLE
[UPDATE] downSample func is Public, and Logic Change

### DIFF
--- a/Sources/SwiftImageCompressor/Extension+UIImage.swift
+++ b/Sources/SwiftImageCompressor/Extension+UIImage.swift
@@ -1,0 +1,85 @@
+//
+//  Extension+UIImage.swift
+//  SwiftImageCompressor
+//
+//  Created by Jae hyung Kim on 6/30/25.
+//
+
+import UIKit
+
+extension UIImage {
+    /// Resize and Compress to target MB
+    /// - Parameters:
+    ///   - type: ImageType (jpeg, png)
+    ///   - targetMB: target size in MB
+    ///   - maxDimension: optional max dimension (default: 2048)
+    /// - Returns: Compressed Data?
+    public func reSizeWithCompressImage(
+        type: ImageType,
+        targetMB: Double,
+        maxDimension: CGFloat = 2048
+    ) -> Data? {
+        return SwiftImageCompressor.shared.resizeAndCompress(self, type: type, targetMB: targetMB, maxDimension: maxDimension)
+    }
+    
+    /// Resize and Compress to target MB
+    /// - Parameters:
+    ///   - type: ImageType (jpeg, png)
+    ///   - targetMB: target size in MB
+    ///   - maxDimension: optional max dimension (default: 2048)
+    /// - Returns: Compressed Data?
+    public func reSizeWithCompressImage(
+        type: ImageType,
+        targetMB: Double,
+        maxDimension: CGFloat = 2048
+    ) async -> Data? {
+        return await SwiftImageCompressor.shared.resizeAndCompress(self, type: type, targetMB: targetMB, maxDimension: maxDimension)
+    }
+    
+    /// Resize and Compress to target MB
+    /// - Parameters:
+    ///   - type: ImageType (jpeg, png)
+    ///   - targetMB: target size in MB
+    ///   - maxDimension: optional max dimension (default: 2048)
+    ///   - completion: Compressed Data?
+    public func reSizeWithCompressImage(
+        type: ImageType,
+        targetMB: Double,
+        maxDimension: CGFloat = 2048,
+        completion: @Sendable @escaping (Data?) -> Void
+    ) {
+        SwiftImageCompressor.shared.resizeAndCompress(self, type: type, targetMB: targetMB, maxDimension: maxDimension, completion: completion)
+    }
+    
+    /// Resizing Image func
+    /// - Parameters:
+    ///   - maxDimension: ex) 2048 -> 2048x2048
+    /// - Returns: UIImage
+    public func resizeImage(maxDimension: CGFloat = 2048) -> UIImage {
+        return SwiftImageCompressor.shared.downSample(self, maxDimension: maxDimension)
+    }
+    
+    /// Compress the given image directly without resizing, targeting a specified file size in MB.
+    /// This function keeps the original image dimensions but compresses it to meet the desired size.
+    /// - Parameters:
+    ///   - type: The desired image format (`jpeg` or `png`).
+    ///   - targetMB: The maximum allowed file size in megabytes.
+    /// - Returns: The compressed image data (`Data?`), or `nil` if compression fails.
+    public func onlyCompressImage(type: ImageType, targetMB: Double) async -> Data? {
+        return await SwiftImageCompressor.shared.onlyCompressImage(self, type: type, targetMB: targetMB)
+    }
+    
+    /// Compress the given image directly without resizing, targeting a specified file size in MB.
+    /// This function keeps the original image dimensions but compresses it to meet the desired size.
+    /// - Parameters:
+    ///   - type: The desired image format (`jpeg` or `png`).
+    ///   - targetMB: The maximum allowed file size in megabytes.
+    ///   - completion: The compressed image data (`Data?`), or `nil` if compression fails.
+    public func onlyCompressImage(
+        type: ImageType,
+        targetMB: Double,
+        completion: @Sendable @escaping (Data?) -> Void
+    ) {
+        SwiftImageCompressor.shared.onlyCompressImage(self, type: type, targetMB: targetMB, completion: completion)
+    }
+}

--- a/Tests/SwiftImageCompressorTests/SwiftImageCompressorUnitTest.swift
+++ b/Tests/SwiftImageCompressorTests/SwiftImageCompressorUnitTest.swift
@@ -19,21 +19,20 @@ final class SwiftImageCompressorUnitTest: XCTestCase {
             return
         }
         
-        let resized = SwiftImageCompressor.shared.resizeImage(image, maxDimension: 100)
+        let resized = SwiftImageCompressor.shared.downSample(image, maxDimension: 100)
         
         XCTAssertLessThanOrEqual(resized.size.width, 100)
         XCTAssertLessThanOrEqual(resized.size.height, 100)
     }
     
-    func testJPEGCompressionShouldReturnSmallerData() {
+    func testJPEGCompressionShouldReturnSmallerData() async {
         let makeImage = makeLargeTestImage()
-        guard let image = makeImage.image,
-             let size = makeImage.size else {
+        guard let image = makeImage.image else {
             XCTFail("Test image could not be created.")
             return
         }
-        let want = Double(size) * 0.8
-        let compressed = SwiftImageCompressor.shared.compressionJPEGEngine(from: image, mbSize: want)
+        let want = 2.0
+        let compressed = await SwiftImageCompressor.shared.onlyCompressImage(image, type: .jpeg, targetMB: want)
         
         if let compressed {
             print("\n want -> \(makeMb(want))\n Compressed IMAGE SIZE ----> ", mbText(compressed.count), "\n")
@@ -47,12 +46,11 @@ final class SwiftImageCompressorUnitTest: XCTestCase {
     
     func testResizeAndCompressFlow() async {
         let makeImage = makeLargeTestImage()
-        guard let image = makeImage.image,
-             let size = makeImage.size else {
+        guard let image = makeImage.image else {
             XCTFail("Test image could not be created.")
             return
         }
-        let want = Double(size) * 0.8
+        let want = 2.0
         let compressed = await SwiftImageCompressor.shared.resizeAndCompress(
             image,
             type: .jpeg,
@@ -70,6 +68,7 @@ final class SwiftImageCompressorUnitTest: XCTestCase {
         }
     }
     
+    /// make Image Result -> 2.9mb Image  With Size
     private func makeLargeTestImage() -> (image: UIImage?, size: Int?) {
         let size = CGSize(width: 6000, height: 6000)
         UIGraphicsBeginImageContext(size)


### PR DESCRIPTION
# [UPDATE]
### 1. The "DownSample" function is converted to "Public".
### 2. Task.detached (operation: _) that was being used internally has been removed
> This means that the task attribute is inherited and applied at the discretion of the developer using the function. When canceling the task, modify the logic so that the internal logic stops.

### 3. Additionally, we have added onlyCompress functions.